### PR TITLE
Keep sponsor link only in homepage footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ backup and disable the module if the host becomes unstable.
 - [Build from source](docs/BUILDING.md)
 - [Release notes](https://github.com/lllucccian/Deekseep/releases)
 - [Report a reproducible problem](https://github.com/lllucccian/Deekseep/issues)
-- [Sponsor development](https://www.afdian.com/a/lllucccian)
 
 Licensed under [GPL-3.0-only](LICENSE).
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -42,7 +42,6 @@ DeepSeek 2.3.4；2.2.0 和 2.3.0 仍可使用但部分功能可能受限；不�
 - [源码构建说明](docs/BUILDING.md)
 - [版本发布说明](https://github.com/lllucccian/Deekseep/releases)
 - [提交可复现问题](https://github.com/lllucccian/Deekseep/issues)
-- [赞助开发](https://www.afdian.com/a/lllucccian)
 
 许可证：[GPL-3.0-only](LICENSE)。
 


### PR DESCRIPTION
Remove duplicate sponsor links from the source section and keep the requested author sponsorship link only at the bottom of both homepages.